### PR TITLE
Support previous and next links with non-standard content

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,14 @@ Just include `responsive-pagination.js` and call the `rPage` function on the pag
         $(".pagination").rPage();
     }); 
     
+Previous and Next Links
+=======================
+
+rPage won't hide previous and next links with bootstrap's default "«" and "»" content. If you want to use custom text in
+your links, add classes to your list items like this:
+
+    <ul class="pagination">
+      <li class="pagination-prev"><a href="#">Previous</a></li>
+      <!-- ... ->
+      <li class="pagination-next"><a href="#">Next</a></li>
+    </ul>

--- a/responsive-paginate.js
+++ b/responsive-paginate.js
@@ -53,11 +53,12 @@ jQuery.fn.rPage = function () {
     	
     	this.isNextOrPrevLink = function(element)
     	{
-    		if (element.text() == "»" || element.text() == "«")
-    		{
-    			return true;
-    		}
-    		return false;
+            return (
+                element.hasClass('pagination-prev')
+                || element.hasClass('pagination-next')
+                || element.text() == "»"
+                || element.text() == "«"
+            );
     	}
     	
     	this.isRemovable = function(element)


### PR DESCRIPTION
Added option to use classes on the list items to identify previous
and next links, to give more flexibility and allow use of custom
content (eg icons, text, etc) in the link element content.
