### PR TITLE
Add composer.json to allow simple integration in php projects

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,21 @@
+{
+    "name": "auxiliary/rpage",
+    "description": "Highly responsive pagination for Bootstrap.",
+    "keywords": ["bootstrap", "css"],
+    "homepage": "http://auxiliary.github.io/rpage/",
+    "authors": [
+        {
+            "name":     "auxiliary",
+            "homepage": "https://github.com/auxiliary"
+        }
+    ],
+    "support": {
+        "issues": "https://github.com/auxiliary/rpage/issues"
+    },
+    "license": "GPL-2.0",
+    "extra": {
+        "branch-alias": {
+            "dev-master": "1.0.x-dev"
+        }
+    }
+}


### PR DESCRIPTION
This will make it easier for end-users to manage the dependency alongside other vendor libraries and packages in a PHP project.

If you're happy to merge this, it would also be great if you could then submit it to https://packagist.org/ and ideally set up a github hook to notify them of any changes.

Thanks
