### PR TITLE
Adding support for component installiation from composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,9 +13,6 @@
         "issues": "https://github.com/auxiliary/rpage/issues"
     },
     "license": "GPL-2.0",
-    "require": {
-        "robloach/component-installer": "*"
-    },
     "extra": {
         "branch-alias": {
             "dev-master": "1.0.x-dev"

--- a/composer.json
+++ b/composer.json
@@ -13,9 +13,18 @@
         "issues": "https://github.com/auxiliary/rpage/issues"
     },
     "license": "GPL-2.0",
+    "require": {
+        "robloach/component-installer": "*"
+    },
     "extra": {
         "branch-alias": {
             "dev-master": "1.0.x-dev"
+        },
+        "component": {
+            "name": "rpage",
+            "scripts": [
+                "responsive-paginate.js"
+            ]
         }
     }
 }


### PR DESCRIPTION
This allows the composer install to copy the resource files (responsive-paginate.js) to be copied into the "public" folder that some sites setup through the component installer script. This allows the js file to be placed outside of the vendor folder easily during install.