### PR TITLE
Update responsive-paginate.js

### DIFF
--- a/responsive-paginate.js
+++ b/responsive-paginate.js
@@ -161,8 +161,14 @@
     	    	var width = 0;
     	    	for (var i = 0; i < $container.find("li").length; i++)
     	    	{
-    	    		width += $container.find("li").eq(i).children("a").eq(0).outerWidth();
-    	    		width += $container.find("li").eq(i).children("span").eq(0).outerWidth();
+    	    		var a       = $container.find("li").eq(i).children("a").eq(0).outerWidth();
+                    var span    = $container.find("li").eq(i).children("span").eq(0).outerWidth();
+                    if(typeof a !== 'undefined' && a > 0) {
+                        width += a;
+                    }
+                    if(typeof span !== 'undefined' && span > 0) {
+                        width += span;
+                    }
     	    	}
     	    	return width;
     	    }


### PR DESCRIPTION
I had an error with the plugin when bower updated jquery for me. I'm still trying to track down if this was a change to JQuery or what. It could have been something I changed in my markup but I don't think so.  Either way, in the old code when there is no span,  outerWidth() is returning undefined and when we try to add that to width, width becomes NaN. This was breaking my pagination in JQuery 2.2.

This modification verifies that we have a number before trying to add it to our width.
