### PR TITLE
Fix for #20 The Function calculateWidth() fails in chrome

### DIFF
--- a/responsive-paginate.js
+++ b/responsive-paginate.js
@@ -161,8 +161,10 @@
     	    	var width = 0;
     	    	for (var i = 0; i < $container.find("li").length; i++)
     	    	{
-    	    		width += $container.find("li").eq(i).children("a").eq(0).outerWidth();
-    	    		width += $container.find("li").eq(i).children("span").eq(0).outerWidth();
+              width += $container.find("li").eq(i).children("a").length
+                && $container.find("li").eq(i).children("a").eq(0).outerWidth();
+              width += $container.find("li").eq(i).children("span").length
+                && $container.find("li").eq(i).children("span").eq(0).outerWidth();
     	    	}
     	    	return width;
     	    }


### PR DESCRIPTION
Checks if child <a> and <span> elements exist when calculating width

Fix for issue #20 