### PR TITLE
Update for jQuery 3

### DIFF
--- a/responsive-paginate.js
+++ b/responsive-paginate.js
@@ -180,7 +180,7 @@
 
     	    var resize_timer;
 
-            $(window).resize(
+            $(window).on("resize",
             	$.proxy(function()
             	{
             		clearTimeout(resize_timer);


### PR DESCRIPTION
I forgot to make this PR ages ago.

This just updated the conventions for resize:
```js
$(window).resize(
```
to
```js
$(window).on("resize",
```